### PR TITLE
replaced property gcpPubsubTopic with gcpPubsubTopicPrefix

### DIFF
--- a/v2/cdc-parent/cdc-embedded-connector/src/main/resources/dataflow_cdc.properties
+++ b/v2/cdc-parent/cdc-embedded-connector/src/main/resources/dataflow_cdc.properties
@@ -3,6 +3,6 @@ databaseUsername=${DB_USERNAME}
 databaseAddress=${DB_ADDRESS}
 databasePort=${DB_PORT}
 gcpProject=${GCP_PROJECT}
-gcpPubsubTopic=${PUBSUB_TOPIC}
+gcpPubsubTopicPrefix=${PUBSUB_TOPIC}
 whitelistedTables=${WHITELISTED_TABLES}
 databasePassword=${DB_PASSWORD}


### PR DESCRIPTION
Replaced property name gcpPubsubTopic with gcpPubsubTopicPrefix. 
Fixes the PubSub topic name being null as App.java was not able to get gcpPubsubTopicPrefix value